### PR TITLE
Reject truncated Windows HTTP responses

### DIFF
--- a/include/clarisma/net/detail/HttpResponseReader_win.inl
+++ b/include/clarisma/net/detail/HttpResponseReader_win.inl
@@ -32,6 +32,10 @@ bool HttpResponseReader<Derived>::get(const char* url, const HttpRequestHeaders&
             {
                 throw HttpException(GetLastError());
             }
+            if (bytesRead == 0)
+            {
+                throw HttpException("Unexpected end of data stream");
+            }
             p += bytesRead;
             remaining -= bytesRead;
         }

--- a/src/clarisma/net/HttpResponse_windows.cxx
+++ b/src/clarisma/net/HttpResponse_windows.cxx
@@ -79,7 +79,10 @@ void HttpResponse::read(std::vector<std::byte>& data)
     if (size)   [[likely]]
     {
         data.resize(size);
-        read(data.data(), size);
+        if (read(data.data(), size) != size)
+        {
+            throw HttpException("Unexpected end of data stream");
+        }
     }
     else
     {


### PR DESCRIPTION
Hello, 

When using `gol.exe` on Windows to load an OpenPlanetData GOB, I stumbled on an issue where the process would occasionally become stuck, making no progress and continuing indefinitely.

This was caused by `WinHttpReadData` successfully returning zero bytes before all expected data had been downloaded. 

This PR adds detection of a premature end-of-response in `HttpResponseReader_win.inl`. It also verifies that responses with a declared `Content-Length` are read completely in `HttpResponse_windows.cxx`. In both cases, a truncated response now throws an exception instead of causing an infinite loop or being silently accepted as complete.