### PR TITLE
gol check: Release tile pages after checking

### DIFF
--- a/src/check/GolChecker.cpp
+++ b/src/check/GolChecker.cpp
@@ -3,6 +3,7 @@
 
 #include "GolChecker.h"
 
+#include <clarisma/io/MappedFile.h>
 #include <clarisma/util/Crc32C.h>
 #include <clarisma/util/DataPtr.h>
 #include <geodesk/feature/FeatureStore.h>
@@ -30,6 +31,8 @@ void GolChecker::processTile(Tip tip, Tile tile)
             checker.check();
         }
 #endif
+        MappedFile::discard(
+            const_cast<uint8_t*>(pTile.ptr()), pTile.totalSize());
     }
     postOutput(tip, ByteBlock());
 }


### PR DESCRIPTION
This depends on https://github.com/clarisma/libgeodesk/pull/45 for correct behavior on Windows. It's one of two PRs addressing https://github.com/clarisma/geodesk-gol/issues/55 .

This PR updates `gol check` to call `MappedFile::discard()` after a tile is checked, preventing its pages from remaining in the process working set.

For a large .gol file on Windows, this reduced peak RAM usage from **34 GB** to **35 MB**.